### PR TITLE
Reproducible (r10e) hermit executables

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build/
+.github/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,6 @@ jobs:
         run: |
           mkdir build testenv
           ./bin/go build -o ./build/hermit ./cmd/hermit
-      - name: (R10e) Build Hermit
-        run: |
-          make r10e-build VERSION=testversion CHANNEL=testchannel
       - name: Install shells
         run: sudo apt-get install zsh
       - name: Run Full Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
         run: |
           mkdir build testenv
           ./bin/go build -o ./build/hermit ./cmd/hermit
+      - name: (R10e) Build Hermit
+        run: |
+          make r10e-build VERSION=testversion CHANNEL=testchannel
       - name: Install shells
         run: sudo apt-get install zsh
       - name: Run Full Integration tests

--- a/.github/workflows/r10e-builds-ci.yml
+++ b/.github/workflows/r10e-builds-ci.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    paths:
+      - 'Dockerfile'
+      - 'r10e-build.sh'
+      - 'Makefile'
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'r10e-build.sh'
+      - 'Makefile'
+  schedule:
+    # Daily at 2am
+    - cron: '0 2 * * *'
+name: R10E-BUILDS-CI
+jobs:
+  it:
+    name: Integration Tests
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: (R10e) Build Hermit
+        run: |
+          make r10e-build VERSION=testversion CHANNEL=testchannel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# The following information is from https://hub.docker.com/r/nixos/nix/tags
+FROM nixos/nix:2.7.0@sha256:3a2c7a7e5ca8b7f4c128174e3fe018811640e7a549cd1aed4b1f1a20ed7786a5 as hermit_builder
+
+ARG version=devel
+ARG channel=canary
+
+#########################################################
+# Step 1: Prepare nixpkgs for deterministic builds
+#########################################################
+WORKDIR /build
+# This commit is tagged as 21.11 in nixpkgs
+ENV NIXPKGS_COMMIT_SHA="a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31"
+
+RUN nix-env --option filter-syscalls false -i git && \
+    mkdir -p /build/nixpkgs && \
+    cd nixpkgs && \
+    git init && \
+    git remote add origin https://github.com/NixOS/nixpkgs.git && \
+    git fetch --depth 1 origin ${NIXPKGS_COMMIT_SHA} && \
+    git checkout FETCH_HEAD && \
+    cd ..
+
+ENV NIX_PATH=nixpkgs=/build/nixpkgs
+
+#########################################################
+# Step 2: Build hermit
+#########################################################
+RUN mkdir -p /build/hermit
+
+COPY . /build/hermit
+
+RUN cd hermit && \
+    nix-shell -p go gnumake \
+      --run "make GOOS=linux GOARCH=amd64 VERSION=$version CHANNEL=$channel build && \
+             make GOOS=linux GOARCH=arm64 VERSION=$version CHANNEL=$channel build && \
+             make GOOS=darwin GOARCH=amd64 VERSION=$version CHANNEL=$channel build && \
+             make GOOS=darwin GOARCH=arm64 VERSION=$version CHANNEL=$channel build" && \
+    cd build && \
+    for f in *.gz; do gunzip "$f"; done && \
+    tar cfz hermits.tar.gz hermit-linux-amd64 hermit-linux-arm64 hermit-darwin-amd64 hermit-darwin-arm64
+

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOOS ?= $(shell ./bin/go version | awk '{print $$NF}' | cut -d/ -f1)
 GOARCH ?= $(shell ./bin/go version | awk '{print $$NF}' | cut -d/ -f2)
 BIN = $(BUILD_DIR)/hermit-$(GOOS)-$(GOARCH)
 
-.PHONY: all build lint test
+.PHONY: all build r10e-build lint test
 
 all: lint test build
 
@@ -20,8 +20,11 @@ test: ## run tests
 
 build: ## builds binary and gzips it
 	mkdir -p build
-	CGO_ENABLED=0 go build -ldflags "-X main.version=$(VERSION) -X main.channel=$(CHANNEL)" -o $(BIN) ./cmd/hermit
+	CGO_ENABLED=0 go build -trimpath -ldflags "-X main.version=$(VERSION) -X main.channel=$(CHANNEL)" -o $(BIN) ./cmd/hermit
 	gzip -9 $(BIN)
+
+r10e-build: ## builds reproducible binaries
+	VERSION="$(VERSION)" CHANNEL="$(CHANNEL)" $(ROOT)/r10e-build.sh 2>/dev/null
 
 help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_\/-]+:.*?## / {printf "\033[34m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | \

--- a/r10e-build.sh
+++ b/r10e-build.sh
@@ -27,7 +27,7 @@ readonly BUILDER_TAG_NAME
 # Self test
 #########################################
 err() {
-  echo -e "$*" >&2
+  echo -e "$*"
   exit 1
 }
 

--- a/r10e-build.sh
+++ b/r10e-build.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Build reproducible hermit binaries for {linux, darwin} on {amd64, arm64}
+#
+# Environment variables:
+# VERSION: if set, version of the hermit binary. Default is a git tag.
+# CHANNEL: if set, the hermit channel. Default is "canary".
+set -euxo pipefail
+
+VERSION="${VERSION:-$(git describe --tags --dirty --always)}"
+CHANNEL="${CHANNEL:-canary}"
+
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+readonly SCRIPT_DIR
+
+OUT_DIR="${SCRIPT_DIR}/r10e-build"
+readonly OUT_DIR
+
+REVISION=$(git --work-tree="${SCRIPT_DIR}" --git-dir="${SCRIPT_DIR}/.git" \
+  rev-parse HEAD)
+readonly REVISION
+
+BUILDER_TAG_NAME="hermit-builder:${REVISION}"
+readonly BUILDER_TAG_NAME
+
+#########################################
+# Self test
+#########################################
+err() {
+  echo -e "$*" >&2
+  exit 1
+}
+
+self_test() {
+  # Check sha256sum
+  command -v sha256sum &>/dev/null || \
+    err "sha256sum not found. Please install coreutils first"
+
+  # Check docker
+  docker stats --no-stream &>/dev/null || \
+    err "Make sure docker daemon is running"
+}
+
+
+self_test
+echo "Build reproducible (r10e) hermit executables"
+cd "${SCRIPT_DIR}"
+docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" \
+  --build-arg channel="${CHANNEL}" --build-arg version="${VERSION}" .
+docker images "${BUILDER_TAG_NAME}"
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+docker run --entrypoint=/bin/sh --rm -i -v "${OUT_DIR}":/tmp/ "${BUILDER_TAG_NAME}" << CMD
+cp /build/hermit/build/hermits.tar.gz /tmp/
+CMD
+
+cd "${OUT_DIR}"
+tar xfz hermits.tar.gz
+echo "==== HERMIT EXECUTABLE INFO ===="
+echo "Reproducible executables created in ${OUT_DIR}."
+echo "Executable sha256sum values:"
+sha256sum hermit-* | sort -k2
+echo


### PR DESCRIPTION
We implement a method to deterministically build hermit executables for
{linux, darwin} on {amd64, arm64}.
    
At a high level, we build the hermit binaries inside a Docker container,
based on a nixOS image and nixpkgs 21.11. This allows us to fix the
build environment and build toolchain.  We also use the `-trimpath`
option in `go build`, to increase the determinism of the builds.
    
The Docker build can be run in CI by a machine and on a laptop by a
human being.
    
To test it out, try

    make r10e-build
    make r10e-build VERSION=testversion CHANNEL=testchannel