### PR TITLE
Add hermit subcommand gen-installer

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,7 +21,7 @@ jobs:
           make GOOS=linux GOARCH=arm64 CHANNEL=canary build
           make GOOS=darwin GOARCH=amd64 CHANNEL=canary build
           make GOOS=darwin GOARCH=arm64 CHANNEL=canary build
-          go run ./cmd/geninstaller --dest=build/install.sh --dist-url=https://github.com/cashapp/hermit/releases/download/canary
+          go run -ldflags "-X main.channel=canary" ./cmd/hermit gen-installer --dest=build/install.sh
       - name: Release canary
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: geninstaller Cross Check
+        run: |
+          BASE_DIST_URL="https://github.com/cashapp/hermit/releases/download"
+          DEST=$(mktemp)
+          for i in {1..42}
+          do
+            CHANNEL=$(head -c 7 /dev/urandom | xxd -p)
+            ./bin/go run ./cmd/geninstaller --dest="${DEST}" --dist-url=https://github.com/cashapp/hermit/releases/download/"${CHANNEL}"
+            sum1=$(openssl dgst -sha256 "${DEST}" | awk '{print $NF}')
+            sum2=$(./bin/go run -ldflags "-X main.channel=${CHANNEL}" ./cmd/hermit gen-installer --dest="${DEST}")
+            [ "${sum1}" = "${sum2}" ] || exit 1
+          done
       - name: Ensure Up-to-date script.sha256 File
         run: |
           ./it/check_script_sha.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           make GOOS=linux GOARCH=arm64 CHANNEL=stable build
           make GOOS=darwin GOARCH=amd64 CHANNEL=stable build
           make GOOS=darwin GOARCH=arm64 CHANNEL=stable build
-          go run ./cmd/geninstaller --dest=build/install.sh --dist-url=https://github.com/cashapp/hermit/releases/download/stable
+          go run -ldflags "-X main.channel=stable" ./cmd/hermit gen-installer --dest=build/install.sh
       - name: Release versioned
         uses: ncipollo/release-action@v1
         with:

--- a/app/commands.go
+++ b/app/commands.go
@@ -45,6 +45,7 @@ type cliBase struct {
 	Search               searchCmd            `cmd:"" help:"Search for packages to install." group:"global"`
 	DumpUserConfigSchema dumpUserConfigSchema `cmd:"" help:"Dump user configuration schema." hidden:""`
 	ScriptSHA            scriptSHACmd         `cmd:"" help:"Print known sha256 sums of activate-hermit and hermit scripts." hidden:""`
+	GenInstaller         genInstallerCmd      `cmd:"" help:"Generate Hermit installer script." group:"global"`
 	kong.Plugins
 }
 

--- a/app/gen_installer_cmd.go
+++ b/app/gen_installer_cmd.go
@@ -3,6 +3,8 @@ package app
 import (
 	"bytes"
 	"crypto/sha256"
+
+	// Embed installer template
 	_ "embed"
 	"encoding/hex"
 	"fmt"
@@ -45,7 +47,7 @@ func GenInstaller(config Config) ([]byte, string, error) {
 	}
 	err := installerTemplate.Execute(&b, p)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.WithStack(err)
 	}
 	sha256sum := sha256.Sum256(b.Bytes())
 	return b.Bytes(), hex.EncodeToString(sha256sum[:]), nil

--- a/app/gen_installer_cmd.go
+++ b/app/gen_installer_cmd.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/alecthomas/hcl"
+	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/state"
+)
+
+var (
+	//go:embed "install.sh.tmpl"
+	installerTemplateSource string
+	installerTemplate       = template.Must(template.New("install.sh").Funcs(template.FuncMap{
+		"string": func(b []byte) string { return string(b) },
+		"words":  func(s []string) string { return strings.Join(s, " ") },
+	}).Parse(installerTemplateSource))
+)
+
+type genInstallerCmd struct {
+	Schema bool   `help:"Display the global schema."`
+	Dest   string `required:"" placeholder:"FILE" help:"Where to write the installer script."`
+}
+
+type params struct {
+	DistURL      string
+	InstallPaths []string
+}
+
+// GenInstaller generates an instaler script from the app configuration.
+// It returns a byte slice of the generated installer script, its
+// SHA-256 digest as a hexadecimal string, and any error encountered.
+func GenInstaller(config Config) ([]byte, string, error) {
+	var b bytes.Buffer
+	p := params{
+		DistURL:      config.BaseDistURL,
+		InstallPaths: config.InstallPaths,
+	}
+	err := installerTemplate.Execute(&b, p)
+	if err != nil {
+		return nil, "", err
+	}
+	sha256sum := sha256.Sum256(b.Bytes())
+	return b.Bytes(), hex.EncodeToString(sha256sum[:]), nil
+}
+
+func (g *genInstallerCmd) Run(config Config) error {
+	if g.Schema {
+		ast, err := hcl.Schema(&state.Config{})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		schema, err := hcl.MarshalAST(ast)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		fmt.Printf("%s\n", schema)
+		return nil
+	}
+
+	w, err := os.Create(g.Dest)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer w.Close() // nolint
+	script, sum, err := GenInstaller(config)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = w.Write(script)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	fmt.Println(sum)
+	return nil
+}

--- a/app/install.sh.tmpl
+++ b/app/install.sh.tmpl
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# shellcheck disable=SC2018,SC2019
+# SC2019: Use '[:upper:]' to support accents and foreign alphabets.
+# SC2018: Use '[:lower:]' to support accents and foreign alphabets.
+
+
+set -euo pipefail
+
+if [ -z "${HERMIT_STATE_DIR:-}" ]; then
+  case "$(uname -s)" in
+  Darwin)
+    HERMIT_STATE_DIR_RAW="\${HOME}/Library/Caches/hermit"
+    ;;
+  Linux)
+    HERMIT_STATE_DIR_RAW="\${XDG_CACHE_HOME:-\${HOME}/.cache}/hermit"
+    ;;
+  esac
+  eval HERMIT_STATE_DIR="${HERMIT_STATE_DIR_RAW}"
+else
+  HERMIT_STATE_DIR_RAW="${HERMIT_STATE_DIR}"
+fi
+
+if [ ! "$(type -P curl)"  ]; then
+    echo "No curl detected in the PATH. Please, install curl before installing Hermit"
+    exit 1
+fi
+
+#  This must be in the form <url>/<channel>
+# eg. https://github.com/cashapp/hermit/releases/download/stable
+HERMIT_DIST_URL="${HERMIT_DIST_URL:-{{.DistURL}}}"
+HERMIT_CHANNEL="$(basename "${HERMIT_DIST_URL}")"
+HERMIT_EXE_RAW="${HERMIT_STATE_DIR_RAW}/pkg/hermit@${HERMIT_CHANNEL}/hermit"
+eval HERMIT_EXE="\${HERMIT_EXE:-${HERMIT_EXE_RAW}}"
+HERMIT_EXE_DIR="$(dirname "${HERMIT_EXE}")"
+
+ID_USER=$(id -u)
+ID_GROUP=$(id -g)
+
+function user_install() {
+  for dir in "${HERMIT_EXE_DIR}" "${HERMIT_STATE_DIR}"; do
+    if [ ! -e "${dir}" ]; then
+      echo "Creating ${dir}"
+      mkdir -p "${dir}"
+      chown "$ID_USER:$ID_GROUP" "${dir}"
+    fi
+
+    if [ ! -w "${dir}" ]; then
+      echo "${dir} is not writeable, making it so"
+      chown "$ID_USER:$ID_GROUP" "${dir}"
+      chmod u+w "${dir}"
+    fi
+  done
+
+  OS="$(uname -s | tr A-Z a-z)"
+  ARCH="$(uname -m | tr A-Z a-z)"
+  if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+  elif [ "$ARCH" = "aarch64" ]; then
+    ARCH="arm64"
+  fi
+  URL="${HERMIT_DIST_URL}/hermit-${OS}-${ARCH}.gz"
+  TMP_FILE="${HERMIT_EXE}.download.${RANDOM}"
+  echo "Downloading ${URL} to ${HERMIT_EXE}"
+  chmod -f u+w "${HERMIT_EXE}" 2> /dev/null || true
+  curl -fsSL "${URL}" | gzip -dc > "${TMP_FILE}"
+  chown "$ID_USER:$ID_GROUP" "${TMP_FILE}"
+  chmod u+wx "${TMP_FILE}"
+  mv "${TMP_FILE}" "${HERMIT_EXE}"
+
+  echo "Hermit installed as ${HERMIT_EXE}"
+}
+
+# Install system-wide components
+function system_install() {
+  local HERMIT_INSTALL_NAME=hermit-${HERMIT_CHANNEL}
+  local CREATE_SYMLINK=1
+  # If HERMIT_BIN_INSTALL_DIR is not set, see if we can detect where Hermit was previously installed.
+  if [ -z "${HERMIT_BIN_INSTALL_DIR:-}" ]; then
+    for dir in {{.InstallPaths|words}}; do
+      # shellcheck disable=SC2016
+      if test -x "${dir}/hermit" && grep -Fq ': "${HERMIT' "${dir}/hermit"; then
+        if ! grep -q '{{.DistURL}}' "${dir}/hermit"; then
+          echo "Found Hermit in ${dir}/hermit but it is a different distribution, not overwriting."
+          CREATE_SYMLINK=
+        fi
+        HERMIT_BIN_INSTALL_DIR="${dir}"
+        break
+      fi
+    done
+    HERMIT_BIN_INSTALL_DIR="${HERMIT_BIN_INSTALL_DIR:-${HOME}/bin}"
+  fi
+  if [ ! -d "$HERMIT_BIN_INSTALL_DIR" ]; then
+    echo "NOTE: $HERMIT_BIN_INSTALL_DIR should be added to your \$PATH if it is not already"
+    mkdir -p "$HERMIT_BIN_INSTALL_DIR"
+  fi
+
+  if [ -e "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME" ]; then
+    echo "Removing the previous $HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+    rm -f "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+  fi
+  cat > "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME" << EOF
+#!/bin/bash
+: "\${HERMIT_EXE:=${HERMIT_EXE_RAW}}"
+test -x \${HERMIT_EXE} && exec "\${HERMIT_EXE}" "\$@"
+(curl -fsSL "${HERMIT_DIST_URL}/install.sh" | bash) && exec "\${HERMIT_EXE}" "\$@"
+EOF
+  chmod +x "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+  if [ -n "${CREATE_SYMLINK}" ]; then
+    echo "Hermit is installed as $HERMIT_BIN_INSTALL_DIR/hermit"
+    ln -fs "$HERMIT_INSTALL_NAME" "$HERMIT_BIN_INSTALL_DIR/hermit"
+  else
+    echo "Hermit is installed as $HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+  fi
+  cat <<-EOF
+
+See https://cashapp.github.io/hermit/usage/get-started/ for more information.
+
+EOF
+}
+
+# Used by system-wide package managers (eg. Homebrew)
+if [ -z "${HERMIT_SKIP_USER_INSTALL:-}" ]; then
+  user_install
+fi
+system_install

--- a/app/main.go
+++ b/app/main.go
@@ -37,6 +37,8 @@ type Config struct {
 	Version     string
 	LogLevel    ui.Level
 	BaseDistURL string
+	// Possible system-wide installation paths
+	InstallPaths []string
 	// SHA256 checksums for all known versions of per-environment scripts.
 	// If empty shell.ScriptSHAs will be used.
 	SHA256Sums  []string
@@ -85,6 +87,11 @@ func (c Config) defaultHTTPClient(logger ui.Logger) *http.Client {
 
 // Main runs the Hermit command-line application with the given config.
 func Main(config Config) {
+	config.InstallPaths = []string{
+		"${HOME}/bin",
+		"/opt/homebrew/bin",
+		"/usr/local/bin",
+	}
 	config.LogLevel = ui.AutoLevel(config.LogLevel)
 	if config.HTTP == nil {
 		config.HTTP = func(config HTTPTransportConfig) *http.Client {

--- a/bin/lint-shell-scripts
+++ b/bin/lint-shell-scripts
@@ -8,5 +8,5 @@ mkdir -p build
 
 go run ./cmd/hermit shell-hooks --zsh --print > $tmpzsh
 go run ./cmd/hermit shell-hooks --bash --print > $tmpbash
-go run ./cmd/geninstaller --dest=./build/install.sh --dist-url=https://github.com/cashapp/hermit/releases/download/stable
+go run -ldflags "-X main.channel=stable" ./cmd/hermit gen-installer --dest=./build/install.sh
 shellcheck -s bash ./build/install.sh ./files/hermit ./files/activate-hermit ./shell/files/sh_common_hooks.sh "$tmpzsh" "$tmpbash" ./it/check_script_sha.sh

--- a/it/common.sh
+++ b/it/common.sh
@@ -27,15 +27,14 @@ fakeRelease() {
   echo "Compiling hermit"
   (
     . ../../bin/activate-hermit
-    go build -o hermit ../../cmd/hermit
-    go install ../../cmd/geninstaller
+    go build -ldflags "-X main.channel=${CHANNEL}" -o hermit ../../cmd/hermit
   )
 
   OS=$(../../bin/go version | awk '{print $NF}' | cut -d/ -f1)
   ARCH=$(../../bin/go version | awk '{print $NF}' | cut -d/ -f2)
   mkdir -p "$DIR"
   gzip -c hermit > "$DIR/hermit-${OS}-${ARCH}.gz"
-  ../../.hermit/go/bin/geninstaller --dest="${DIR}/install.sh" --dist-url=https://github.com/cashapp/hermit/releases/download/"${CHANNEL}"
+  ./hermit gen-installer --dest="${DIR}/install.sh"
 
   export HERMIT_DIST_URL=file://$PWD/$DIR
   echo $HERMIT_DIST_URL


### PR DESCRIPTION
Add hermit gen-installer subcommand. It prints the SHA-256 digest of the generated installer script to stdout.

Use hermit gen-installer to generate installer script
    
We also perform a cross-check in CI to make sure `cmd/geninstaller` and
`hermit gen-installer` produce identical installer scripts.
