### PR TITLE
Support autoversion package sha256 verification

### DIFF
--- a/manifest/config.go
+++ b/manifest/config.go
@@ -40,7 +40,8 @@ type Layer struct {
 	Vars        map[string]string `hcl:"vars,optional" help:"Set local variables used during manifest evaluation."`
 	Source      string            `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
 	Mirrors     []string          `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
-	SHA256      string            `hcl:"sha256,optional" help:"SHA256 of source package for verification."`
+	SHA256      string            `hcl:"sha256,optional" help:"SHA256 of source package for verification. When in conflict with SHA256 in sha256sums, this value takes precedence."`
+	SHA256Sums  map[string]string `hcl:"sha256sums,optional" help:"SHA256 checksums of source packages for verification."`
 	Darwin      []*Layer          `hcl:"darwin,block" help:"Darwin-specific configuration."`
 	Linux       []*Layer          `hcl:"linux,block" help:"Linux-specific configuration."`
 	Platform    []*PlatformBlock  `hcl:"platform,block" help:"Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc.."`


### PR DESCRIPTION
This change makes it possible to do package sha256 check during package
installation for autoversioned packages. We do so by using an atrribute
named `sha256sums` in the package manifest file, which is a map of
format

    {
     source1: source1_sha256,
     source2: source2_sha256
    }

e.g,

    sha256sums = {
      "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06",
      "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9054"
    }

When the package sha256 checksums in the `sha256` and `sha256sums`
attribtes do not agree, the `sha256` attribute takes precedence over the
`sha256sums` attribute, for package integrity verification.